### PR TITLE
Added login functionality + wildcard globbing 

### DIFF
--- a/xv6/Makefile
+++ b/xv6/Makefile
@@ -172,6 +172,7 @@ UPROGS=\
 	_grep\
 	_init\
 	_kill\
+	_login\
 	_ln\
 	_ls\
 	_mkdir\

--- a/xv6/init.c
+++ b/xv6/init.c
@@ -5,7 +5,24 @@
 #include "user.h"
 #include "fcntl.h"
 
-char *argv[] = { "sh", 0 };
+
+
+static void ensure_passwd(void){
+    int fd=open("passwd",O_RDONLY);
+    if(fd>=0){close(fd); return;}  //already exists
+    fd=open("passwd", O_CREATE| O_WRONLY);
+    if(fd<0){
+      printf(1,"init : Can't create passwd\n");
+      return;
+    }
+   const char *l1 = "lynn:l523Z@aub\n";
+   const char *l2 = "GhinaSabbagh:Ghinasab5678\n";
+
+  write(fd, l1, strlen(l1));
+  write(fd, l2, strlen(l2));
+  close(fd);
+}
+ 
 
 int
 main(void)
@@ -16,22 +33,25 @@ main(void)
     mknod("console", 1, 1);
     open("console", O_RDWR);
   }
-  dup(0);  // stdout
-  dup(0);  // stderr
+   dup(0);  // stdout
+   dup(0);  // stderr
+   ensure_passwd(); 
 
   for(;;){
-    printf(1, "init: starting sh\n");
+    printf(1, "init: starting login\n");
     pid = fork();
     if(pid < 0){
       printf(1, "init: fork failed\n");
       exit();
     }
     if(pid == 0){
-      exec("sh", argv);
-      printf(1, "init: exec sh failed\n");
+      char *argv_login[] = { "login", 0 };
+      exec("login", argv_login);
+      printf(1, "init: exec login failed\n");
       exit();
     }
     while((wpid=wait()) >= 0 && wpid != pid)
       printf(1, "zombie!\n");
   }
+
 }

--- a/xv6/login.c
+++ b/xv6/login.c
@@ -1,0 +1,110 @@
+// user/login.c — file-based login for xv6
+#include "types.h"
+#include "stat.h"
+#include "user.h"
+#include "fcntl.h"
+
+#define MAXLINE 128
+
+static void readline(char *buf, int sz) {
+  int i = 0;
+  while (i + 1 < sz) {
+    char c;
+    int n = read(0, &c, 1);
+    if (n < 1) break;
+    if (c == '\r') continue;
+    if (c == '\n') break;
+    buf[i++] = c;
+  }
+  buf[i] = 0;
+}
+
+static int equals(const char *a, const char *b) {
+  return strcmp(a, b) == 0;
+}
+
+static int check_passwd(const char *user, const char *pass) {
+  int fd = open("passwd", O_RDONLY);
+  if (fd < 0) {
+    printf(1, "login: cannot open passwd file\n");
+    return 0;
+  }
+
+  char line[MAXLINE];
+  int i = 0;
+  char ch;
+  int n;
+
+  while ((n = read(fd, &ch, 1)) == 1) {
+    if (ch == '\n' || i >= MAXLINE - 1) {
+      // terminate current line
+      line[i] = 0;
+      // parse "name:pw"
+      if (i > 0) {
+        char *colon = 0;
+        for (int k = 0; k < i; k++) {
+          if (line[k] == ':') { colon = &line[k]; break; }
+        }
+        if (colon) {
+          *colon = 0;
+          const char *name = line;
+          const char *pw   = colon + 1;
+          if (equals(name, user) && equals(pw, pass)) {
+            close(fd);
+            return 1;
+          }
+        }
+      }
+      i = 0; // reset for next line
+    } else {
+      line[i++] = ch;
+    }
+  }
+
+  // handle last line if it didn't end with newline
+  if (i > 0) {
+    line[i] = 0;
+    char *colon = 0;
+    for (int k = 0; k < i; k++) {
+      if (line[k] == ':') { colon = &line[k]; break; }
+    }
+    if (colon) {
+      *colon = 0;
+      const char *name = line;
+      const char *pw   = colon + 1;
+      if (equals(name, user) && equals(pw, pass)) {
+        close(fd);
+        return 1;
+      }
+    }
+  }
+
+  close(fd);
+  return 0;
+}
+
+int
+main(void)
+{
+  char user[32], pass[32];
+
+  printf(1, "\n=== xv6 login ===\n");
+  for (;;) {
+    printf(1, "Username: ");
+    readline(user, sizeof user);
+
+    // NOTE: xv6 console echoes input; password won't be hidden.
+    printf(1, "Password: ");
+    readline(pass, sizeof pass);
+
+    if (check_passwd(user, pass)) {
+      printf(1, "Login ok. Starting sh...\n");
+      char *argv[] = { "sh", 0 };
+      exec("sh", argv);
+      printf(1, "login: exec sh failed\n");
+      exit();
+    } else {
+      printf(1, "Login failed. Try again.\n");
+    }
+  }
+}

--- a/xv6/sh.c
+++ b/xv6/sh.c
@@ -3,6 +3,7 @@
 #include "types.h"
 #include "user.h"
 #include "fcntl.h"
+#include "fs.h"
 
 // Parsed command representation
 #define EXEC  1
@@ -53,6 +54,59 @@ int fork1(void);  // Fork but panics on failure.
 void panic(char*);
 struct cmd *parsecmd(char*);
 
+
+//function to check if a string contains * 
+static int has_star(const char *s){
+  for(;*s;s++) if (*s=='*') return 1;
+  return 0;
+}
+//matcher function 
+static int match(const char *pat,const char *s){
+  if( *pat ==0) return *s==0;
+  if(*pat =='*')
+    return match(pat+1,s) || (*s && match(pat,s+1));
+  return *pat== *s && match(pat+1,s+1);
+}
+//add one argv entry 
+static void addarg(char **argv,int *argc , char *s,int max){
+  if(*argc +1 < max)
+    argv[(*argc)++]=s;
+}
+static int expand_glob(char *pat, char **nargv, int *nargc, int maxargs){
+  int fd = open(".", 0);
+  if(fd < 0)
+    return 0;
+
+  struct dirent de;
+  int matches = 0;
+
+  // If pattern doesn’t start with '.', skip hidden files.
+  int showdot = (pat[0] == '.');
+
+  while(read(fd, &de, sizeof(de)) == sizeof(de)){
+    if(de.inum == 0) continue;
+
+    // copy name into a C-string
+    char name[DIRSIZ+1];
+    memmove(name, de.name, DIRSIZ);
+    name[DIRSIZ] = 0;
+
+    if(!showdot && name[0] == '.') continue;
+
+    if(match(pat, name)){
+      char *dup = malloc(strlen(name)+1);
+      if(!dup) break;
+      strcpy(dup, name);
+      addarg(nargv, nargc, dup, maxargs);
+      matches++;
+    }
+  }
+
+  close(fd);
+  return matches;
+}
+
+
 // Execute cmd.  Never returns.
 void
 runcmd(struct cmd *cmd)
@@ -71,14 +125,48 @@ runcmd(struct cmd *cmd)
   default:
     panic("runcmd");
 
-  case EXEC:
-    ecmd = (struct execcmd*)cmd;
-    if(ecmd->argv[0] == 0)
-      exit();
-    exec(ecmd->argv[0], ecmd->argv);
-    printf(2, "exec %s failed\n", ecmd->argv[0]);
-    break;
+  case EXEC: {
+  struct execcmd *ecmd = (struct execcmd*)cmd;
+  if(ecmd->argv[0] == 0)
+    exit();
 
+  // Build a new argv with wildcard expansion.
+  // MAXARGS is defined in sh.c; keep using it.
+  char *nargv[MAXARGS];
+  int nargc = 0;
+
+  for(int i = 0; ecmd->argv[i] && nargc+1 < MAXARGS; i++){
+    char *arg = ecmd->argv[i];
+
+    if(has_star(arg)){
+      // try expanding; if no matches, keep the literal
+      int before = nargc;
+      int got = expand_glob(arg, nargv, &nargc, MAXARGS);
+      if(got == 0){
+        // keep literal
+        char *dup = malloc(strlen(arg)+1);
+        if(dup){
+          strcpy(dup, arg);
+          addarg(nargv, &nargc, dup, MAXARGS);
+        }
+      }
+    } else {
+      // keep as-is
+      char *dup = malloc(strlen(arg)+1);
+      if(dup){
+        strcpy(dup, arg);
+        addarg(nargv, &nargc, dup, MAXARGS);
+      }
+    }
+  }
+  nargv[nargc] = 0;
+
+  // exec the expanded argv
+  exec(nargv[0], nargv);
+  printf(2, "exec %s failed\n", nargv[0]);
+  break;
+  }
+  
   case REDIR:
     rcmd = (struct redircmd*)cmd;
     close(rcmd->fd);


### PR DESCRIPTION
Implement a login gate so users must authenticate before getting a shell.
Add * wildcard (globbing) in the shell so commands like ls *.txt expand to matching files.
Rationale: keep kernel unchanged (auth in user space) and give common shell usability without touching every program.